### PR TITLE
Automatically open a new migration after creation

### DIFF
--- a/build/tools/dbup-consolescripts.psm1
+++ b/build/tools/dbup-consolescripts.psm1
@@ -37,6 +37,7 @@ function New-Migration {
    $item = $targetProjectItem.ProjectItems.Item($fileName) 
    $item.Properties.Item("BuildAction").Value = [int]3 #Embedded Resource
    Write-Host "Created new migration: ${fileName}"
+   $dte.ExecuteCommand("File.OpenFile", $filePath)
 }
 
 function Start-Migrations {


### PR DESCRIPTION
After creating a new migration using the `new-migration` command, directly open the file in Visual Studio so it can be edited.
