### PR TITLE
Fix for auto open file when path contains spaces

### DIFF
--- a/build/tools/dbup-consolescripts.psm1
+++ b/build/tools/dbup-consolescripts.psm1
@@ -37,7 +37,7 @@ function New-Migration {
    $item = $targetProjectItem.ProjectItems.Item($fileName) 
    $item.Properties.Item("BuildAction").Value = [int]3 #Embedded Resource
    Write-Host "Created new migration: ${fileName}"
-   $dte.ExecuteCommand("File.OpenFile", $filePath)
+   $dte.ExecuteCommand("File.OpenFile", $scriptsDirectoryName + "\" + $fileName)
 }
 
 function Start-Migrations {


### PR DESCRIPTION
Apparently my initial contribution shows an error dialog when the full path contains spaces. The proposed change opens the file using just the relative filename `Scripts\[file].sql` which works even when the full project/solution folder is very long and has spaces.