### PR TITLE
Add encoding to New-Migration

### DIFF
--- a/build/tools/dbup-consolescripts.psm1
+++ b/build/tools/dbup-consolescripts.psm1
@@ -2,7 +2,8 @@
 
 function New-Migration {
   param (
-    [string] $Name
+    [string] $Name,
+    [string] $Encoding = ""
   )
 
    $project = Get-Project
@@ -32,7 +33,15 @@ function New-Migration {
    $fileName = $fileNameBase + ".sql"
    $filePath = $scriptDirectory + "\" + $fileName
 
-   New-Item -path $scriptDirectory -name $fileName -type "file" -value "/* Migration Script */" | Out-Null
+   New-Item -path $scriptDirectory -name $fileName -type "file" | Out-Null
+   try
+   {
+      "/* Migration Script */" | Out-File -Encoding $Encoding -FilePath $filePath
+   }
+   catch
+   {
+      "/* Migration Script */" | Out-File -Encoding ascii -FilePath $filePath
+   }
    $targetProjectItem.ProjectItems.AddFromFile($filePath) | Out-Null
    $item = $targetProjectItem.ProjectItems.Item($fileName) 
    $item.Properties.Item("BuildAction").Value = [int]3 #Embedded Resource


### PR DESCRIPTION
I added the possibility to add encoding to the "New-Migration" command.

My motivation was that we have (unfortunately) umlauts in some of our scripts and with the command the file is ANSI-encoded, so the umlauts got changed to some kind of question mark which caused trouble in our database.

If no or no valid encoding is passed it'll use the ANSI-encoding for the new migration file.