### PR TITLE
Update dbup-consolescripts.psm1

### DIFF
--- a/build/tools/dbup-consolescripts.psm1
+++ b/build/tools/dbup-consolescripts.psm1
@@ -55,7 +55,7 @@ function Start-Migrations {
   )
 
   $project = Get-Project
-  $outputPath = $project.ConfigurationManager.ActiveConfiguration.Properties["OutputPath"].Value
+  $outputPath = $project.ConfigurationManager.ActiveConfiguration.Properties.Item("OutputPath").Value
   $activeConfiguration = $dte.Solution.SolutionBuild.ActiveConfiguration.Name  
   Write-Host "Building..."
   $dte.Solution.SolutionBuild.BuildProject($activeConfiguration, $project.FullName, $true)


### PR DESCRIPTION
Fix: Unable to index into an object of type System.__ComObject.
At line:1 char:62
+ $project.ConfigurationManager.ActiveConfiguration.Properties[ <<<< "OutputPath"].Value
    + CategoryInfo          : InvalidOperation: (OutputPath:String) [], RuntimeException
    + FullyQualifiedErrorId : CannotIndex