### PR TITLE
.Net Core Console App

### DIFF
--- a/dbup-consolescripts.psm1
+++ b/dbup-consolescripts.psm1
@@ -48,8 +48,14 @@ function Start-Migrations {
         $args = $args + " --whatif"
     }
 
-  $projectExe = $projectDirectory + "\" + $outputPath + $outputAssemblyName + ".exe"
-  & $projectExe $args
+  If($outputPath.IndexOf("netcoreapp") -ge 0) {
+	$projectCmd = $projectDirectory + "\" + $outputPath + $outputAssemblyName + ".dll"
+	dotnet $projectCmd $args
+  }
+  Else {
+    $projectExe = $projectDirectory + "\" + $outputPath + $outputAssemblyName + ".exe"
+    & $projectExe $args
+  }
 }
  
 


### PR DESCRIPTION
This is a change to the start-migrations script so it will run the "dotnet" command on the dll output that you get when DBUP is hosted in a .Net Core Console App.